### PR TITLE
Turn off IO buffer

### DIFF
--- a/src/memcached/client.cr
+++ b/src/memcached/client.cr
@@ -53,6 +53,7 @@ module Memcached
     def initialize(host = "localhost", port = 11211)
       Memcached.logger.info("Connecting to #{host}:#{port}")
       @socket = TCPSocket.new(host, port)
+      @socket.sync = false
     end
 
     #:nodoc:


### PR DESCRIPTION
Disables buffering, writing the content to IO right after the command
being executed improving performance.
