### PR TITLE
Update integer variable type

### DIFF
--- a/src/memcached/client.cr
+++ b/src/memcached/client.cr
@@ -409,7 +409,7 @@ module Memcached
                              key : Array(UInt8),
                              value : Array(UInt8),
                              extras : Array(UInt8),
-                             version : Int64 = 0)
+                             version : Int64 = 0_i64)
       v = version.to_i64
       extras_length = extras.size.to_u8
       key_length = key.size.to_u16


### PR DESCRIPTION
Crystal 0.20.4 has a breaking change whereby default variables need to be the same as their type restriction.

https://github.com/crystal-lang/crystal/blob/master/CHANGELOG.md

https://github.com/crystal-lang/crystal/pull/3834

Integers now need a suffix to define their type or they will default to Int32.
> If no suffix is present, the literal's type is the lowest between `Int32`, `Int64` and `UInt64`.

https://crystal-lang.org/docs/syntax_and_semantics/literals/integers.html

When running the specs I get:
```
crystal spec
Error in line 1: while requiring "./spec/memcached/client_spec.cr"

in spec/memcached/client_spec.cr:6: instantiating 'Memcached::Client#flush()'

    client.flush
           ^~~~~

in src/memcached/client.cr:258: instantiating 'flush(UInt32)'

    def flush(delay = 0_u32) : Bool
    ^

in src/memcached/client.cr:259: instantiating 'send_request(UInt8, Array(UInt8), Array(UInt8), Array(UInt8))'

      send_request(
      ^~~~~~~~~~~~

in src/memcached/client.cr:412: can't restrict Int32 to Int64

                             version : Int64 = 0)
                             ^

```